### PR TITLE
Set gin context with rate-limiting data

### DIFF
--- a/drivers/middleware/gin/middleware.go
+++ b/drivers/middleware/gin/middleware.go
@@ -44,6 +44,10 @@ func (middleware *Middleware) Handle(c *gin.Context) {
 		return
 	}
 
+	c.Set("RateLimit-Limit", context.Limit)
+	c.Set("RateLimit-Remaining", context.Remaining)
+	c.Set("RateLimit-Reset", context.Reset)
+
 	c.Header("X-RateLimit-Limit", strconv.FormatInt(context.Limit, 10))
 	c.Header("X-RateLimit-Remaining", strconv.FormatInt(context.Remaining, 10))
 	c.Header("X-RateLimit-Reset", strconv.FormatInt(context.Reset, 10))


### PR DESCRIPTION
This allows the library client to customize the rate limiting
behavior.